### PR TITLE
Add ability to deactivate from WP CLI

### DIFF
--- a/lib/fewbricks.php
+++ b/lib/fewbricks.php
@@ -47,7 +47,16 @@ class fewbricks {
 
             }
 
-        } else {
+          } else if ( defined( 'WP_CLI' ) && WP_CLI ) {
+              //added in case something goes wrong and we need to deactivate the plugin from WP CLI!
+              if( self::acf_exists() &&
+                self::fewbricks_hidden_exists() &&
+                self::fewbricks_template_dir_exists())
+              {
+                  self::add_fewbricks_hidden_activated_check();
+                  self::init();
+              }
+          } else {
             // Not in admin system, so assume that all is good.
 
             self::init();


### PR DESCRIPTION
If for whatever reason a dev does not have the necessary requirements met after logging out of the WP admin, fewbricks will fail even when trying to log back into the admin or trying to do anything from the WP CLI.

This just makes it so someone can deactivate fewbricks from WP CLI in order to log back in and set things straight.

Basically... I left things unfinished because I'm trying out some different things in my theme with composer, and screwed myself, so I thought this quick fix might help someone else. 😆 